### PR TITLE
[NTS-UI/nui.calendar#15] 캘린더 상태 Context 및 Reducer 작성

### DIFF
--- a/src/contexts/calendar.js
+++ b/src/contexts/calendar.js
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useReducer } from 'react'
+import calendarReducer from '../reducers/calendar'
+
+const appContext = createContext(null)
+
+const { Provider } = appContext
+
+const initialState = {
+	list: [],
+}
+
+const initializer = () => {}
+
+export const AppContext = ({ children }) => {
+	const [calendarStore, calendarDispatch] = useReducer(calendarReducer, initialState, initializer)
+
+	return (
+		<Provider
+			value={{
+				CalendarContext: {
+					calendarStore,
+					calendarDispatch,
+				},
+			}}
+		>
+			{children}
+		</Provider>
+	)
+}
+
+export const useCalenderContext = () => useContext(appContext).CalendarContext

--- a/src/reducers/calendar.js
+++ b/src/reducers/calendar.js
@@ -1,0 +1,76 @@
+import { useReducer } from 'react'
+
+/**
+ * Ducks Patterns
+ *
+ * ref: // Ducks Patters *ref: http://guswnsxodlf.github.io/redux-ducks-pattern
+ */
+const ACTIONS = {
+	CREATE: 'nui.calendar/calendar/CREATE',
+	READ: 'nui.calendar/calendar/READ',
+	UPDATE: 'nui.calendar/calendar/UPDATE',
+	DELETE: 'nui.calendar/calendar/DELETE',
+}
+
+const reducer = ({ state = { list: [] }, actions = { type: '', calendar: {} } }) => {
+	const calendar = actions.calendar
+	const { startAt } = calendar
+	const calendarList = state[startAt]
+
+	switch (actions.type) {
+		case ACTIONS.CREATE:
+			return {
+				...state,
+				[startAt]: [...calendarList, calendar],
+			}
+		case ACTIONS.READ:
+			return {
+				list: [...state],
+			}
+		case ACTIONS.UPDATE:
+			const newCalendar = calendarList.find((item) => item.id === calendar.id)
+
+			return {
+				...state,
+				[startAt]: [...calendarList, newCalendar],
+			}
+		case ACTIONS.DELETE:
+			const newCalendarList = calendarList.filter((item) => item.id !== calendar.id)
+
+			return {
+				...state,
+				[startAt]: newCalendarList,
+			}
+		default:
+			return state
+	}
+}
+
+export const createCalendar = (calendar) => {
+	return {
+		type: ACTIONS.CREATE,
+		calendar,
+	}
+}
+
+export const removeCalendar = () => {
+	return {
+		type: ACTIONS.READ,
+	}
+}
+
+export const updateCalendar = (calendar) => {
+	return {
+		type: ACTIONS.UPDATE,
+		calendar,
+	}
+}
+
+export const deleteCalendar = (calendar) => {
+	return {
+		type: ACTIONS.DELETE,
+		calendar,
+	}
+}
+
+export default reducer


### PR DESCRIPTION
[NTS-UI/nui.calendar#15]
캘린더의 상태를 관리하기 위한 Context 생성
추후 Redux 패턴의 확장성을 고려하여 `useReducer` 사용 가능한 reducer 작성